### PR TITLE
Handle exceptions better

### DIFF
--- a/src/main/java/net/torocraft/minecoprocessors/ClientProxy.java
+++ b/src/main/java/net/torocraft/minecoprocessors/ClientProxy.java
@@ -1,11 +1,24 @@
 package net.torocraft.minecoprocessors;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.torocraft.minecoprocessors.blocks.BlockMinecoprocessor;
 
 public class ClientProxy extends CommonProxy {
+
+  private boolean toldPlayerAboutException = false;
+
+  @Override
+  public void handleUnexpectedException(Exception e) {
+    super.handleUnexpectedException(e);
+    if(!toldPlayerAboutException) {
+      toldPlayerAboutException = true;
+      Minecraft.getMinecraft().ingameGUI.getChatGUI().printChatMessage(new TextComponentTranslation("minecoprocessors.error_chat"));
+    }
+  }
 
   @Override
   public void preInit(FMLPreInitializationEvent e) {

--- a/src/main/java/net/torocraft/minecoprocessors/CommonProxy.java
+++ b/src/main/java/net/torocraft/minecoprocessors/CommonProxy.java
@@ -16,6 +16,10 @@ public class CommonProxy {
 
   public Logger logger;
 
+  public void handleUnexpectedException(Exception e) {
+    e.printStackTrace();
+  }
+
   public void preInit(FMLPreInitializationEvent e) {
     logger = e.getModLog();
     int packetId = 0;

--- a/src/main/java/net/torocraft/minecoprocessors/blocks/TileEntityMinecoprocessor.java
+++ b/src/main/java/net/torocraft/minecoprocessors/blocks/TileEntityMinecoprocessor.java
@@ -370,8 +370,8 @@ public class TileEntityMinecoprocessor extends TileEntity implements ITickable, 
       if (name != null && !name.isEmpty()) {
         return name;
       }
-    }catch(Exception ignore){
-
+    } catch (Exception e){
+      Minecoprocessors.proxy.handleUnexpectedException(e);
     }
     return null;
   }

--- a/src/main/java/net/torocraft/minecoprocessors/gui/GuiMinecoprocessor.java
+++ b/src/main/java/net/torocraft/minecoprocessors/gui/GuiMinecoprocessor.java
@@ -1,5 +1,7 @@
 package net.torocraft.minecoprocessors.gui;
 
+import java.util.List;
+
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
@@ -132,10 +134,16 @@ public class GuiMinecoprocessor extends net.minecraft.client.gui.inventory.GuiCo
     String label = "NEXT";
 
     byte[] a = null;
-    try {
-      a = processor.getProgram().get(processor.getIp());
-    } catch (Exception e) {
-      a = null;
+    if(processor != null) {
+      try {
+        int ip = processor.getIp();
+        List<byte[]> program = processor.getProgram();
+        if(ip < program.size()) {
+          a = program.get(ip);
+        }
+      } catch (Exception e) {
+        Minecoprocessors.proxy.handleUnexpectedException(e);
+      }
     }
 
     int color = 0xffffff;

--- a/src/main/java/net/torocraft/minecoprocessors/network/MessageEnableGuiUpdates.java
+++ b/src/main/java/net/torocraft/minecoprocessors/network/MessageEnableGuiUpdates.java
@@ -69,7 +69,7 @@ public class MessageEnableGuiUpdates implements IMessage {
         TileEntityMinecoprocessor mp = (TileEntityMinecoprocessor) player.world.getTileEntity(message.pos);
         mp.enablePlayerGuiUpdates(player, message.enable);
       } catch (Exception e) {
-        e.printStackTrace();
+        Minecoprocessors.proxy.handleUnexpectedException(e);
       }
     }
 

--- a/src/main/java/net/torocraft/minecoprocessors/network/MessageProcessorAction.java
+++ b/src/main/java/net/torocraft/minecoprocessors/network/MessageProcessorAction.java
@@ -86,7 +86,7 @@ public class MessageProcessorAction implements IMessage {
         }
 
       } catch (Exception e) {
-        e.printStackTrace();
+        Minecoprocessors.proxy.handleUnexpectedException(e);
       }
     }
 

--- a/src/main/java/net/torocraft/minecoprocessors/processor/Processor.java
+++ b/src/main/java/net/torocraft/minecoprocessors/processor/Processor.java
@@ -6,6 +6,7 @@ import java.util.List;
 import net.minecraft.nbt.NBTTagByteArray;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.torocraft.minecoprocessors.Minecoprocessors;
 import net.torocraft.minecoprocessors.util.ByteUtil;
 import net.torocraft.minecoprocessors.util.InstructionUtil;
 import net.torocraft.minecoprocessors.util.Label;
@@ -300,7 +301,8 @@ public class Processor implements IProcessor {
 
     try {
       process();
-    }catch (Exception e) {
+    } catch (Exception e) {
+      Minecoprocessors.proxy.handleUnexpectedException(e);
       error = getInstructionString();
       fault = true;
     }
@@ -312,6 +314,7 @@ public class Processor implements IProcessor {
     try{
       return InstructionUtil.compileLine(instruction, labels, ip);
     } catch(Exception e) {
+      Minecoprocessors.proxy.handleUnexpectedException(e);
       return "??";
     }
   }
@@ -543,6 +546,11 @@ public class Processor implements IProcessor {
   }
 
   private void processRet() {
+    if (sp <= 1) {
+      fault = true;
+      error = "ret";
+      return;
+    }
     ip = ByteUtil.setByteInShort(ip, stack[--sp], 1);
     ip = ByteUtil.setByteInShort(ip, stack[--sp], 0);
   }
@@ -565,7 +573,7 @@ public class Processor implements IProcessor {
       assert ip == (short) 0xabcd;
       assert sp == 0;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -588,7 +596,7 @@ public class Processor implements IProcessor {
       processInc();
       assertRegisters(0, 0, 0, 0);
       assert zero;
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -611,7 +619,7 @@ public class Processor implements IProcessor {
       processDec();
       assertRegisters(0, 0, 0, 0);
       assert zero;
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -636,7 +644,7 @@ public class Processor implements IProcessor {
       processMul();
       assertRegisters(10, 0, 0, 2);
       assert !zero;
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -670,7 +678,7 @@ public class Processor implements IProcessor {
       assertRegisters(5, 0, 0, 0);
       assert !zero;
       assert fault;
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -794,7 +802,7 @@ public class Processor implements IProcessor {
       setupTest(0, 30, 0, 0, "mov a, 51");
       processMov();
       assertRegisters(51, 30, 0, 0);
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -831,7 +839,7 @@ public class Processor implements IProcessor {
       assert !overflow;
       assert !zero;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -856,7 +864,7 @@ public class Processor implements IProcessor {
       assert !overflow;
       assert zero;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -881,7 +889,7 @@ public class Processor implements IProcessor {
       assert !overflow;
       assert zero;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -898,7 +906,7 @@ public class Processor implements IProcessor {
       assertRegisters(0, 0b010, 0, 0);
       assert zero;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -915,7 +923,7 @@ public class Processor implements IProcessor {
       assertRegisters(0, 0b0101, 0, 0);
       assert zero;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -932,7 +940,7 @@ public class Processor implements IProcessor {
       assertRegisters(0, 0, 0, 0);
       assert zero;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -949,7 +957,7 @@ public class Processor implements IProcessor {
       assertRegisters(0, 0, 0, 0);
       assert zero;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -961,7 +969,7 @@ public class Processor implements IProcessor {
       assertRegisters(0, 0, 0, 0);
       assert ip == (short) 111;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -981,7 +989,7 @@ public class Processor implements IProcessor {
       assertRegisters(0, 0, 0, 0);
       assert ip == 0;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -1000,7 +1008,7 @@ public class Processor implements IProcessor {
       assertRegisters(0, 0, 0, 0);
       assert ip == 0;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -1027,7 +1035,7 @@ public class Processor implements IProcessor {
       assertRegisters(0b010, 20, 0, 0);
       assert !zero;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -1050,7 +1058,7 @@ public class Processor implements IProcessor {
       assertRegisters(0, 8, 0, 0);
       assert zero;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }
@@ -1076,7 +1084,7 @@ public class Processor implements IProcessor {
       assert sp == 1;
       assert registers[Register.B.ordinal()] == (byte) 30;
 
-    } catch (Exception e) {
+    } catch (ParseException e) {
       throw new AssertionError(e);
     }
   }

--- a/src/main/resources/assets/minecoprocessors/lang/en_US.lang
+++ b/src/main/resources/assets/minecoprocessors/lang/en_US.lang
@@ -6,3 +6,4 @@ gui.button.reset=reset
 gui.button.sleep=sleep
 gui.button.step=step
 gui.button.wake=wake
+minecoprocessors.error_chat=An unexpected exception occurred in Minecoprocessors. This may cause severe problems and should be reported to the deveoper. Details have been logged.


### PR DESCRIPTION
- If an unexpected exception occurs, make sure we log it and tell the player
- Make sure the processor and instruction exist before trying to print it
- Set fault early rather than letting an ArrayIndexOutOfBoundsException happen if there's a ret without a call
- Make "expected" exceptions be more specific