### PR TITLE
Clean up code related to the new manual

### DIFF
--- a/src/main/java/net/torocraft/minecoprocessors/gui/GuiMinecoprocessor.java
+++ b/src/main/java/net/torocraft/minecoprocessors/gui/GuiMinecoprocessor.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.GuiScreenBook;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.inventory.IInventory;
-import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -321,7 +320,7 @@ public class GuiMinecoprocessor extends net.minecraft.client.gui.inventory.GuiCo
     }
     if (button == buttonHelp) {
       // TODO override the book GUI so that it returns the processor GUI when closed
-      this.mc.displayGuiScreen(new GuiScreenBook(mc.player, BookCreator.createBook("manual"), false));
+      this.mc.displayGuiScreen(new GuiScreenBook(mc.player, BookCreator.manual, false));
     }
   }
 

--- a/src/main/java/net/torocraft/minecoprocessors/util/BookCreator.java
+++ b/src/main/java/net/torocraft/minecoprocessors/util/BookCreator.java
@@ -20,30 +20,38 @@ public class BookCreator {
 
   private static final String PATH = "/assets/minecoprocessors/books/";
   private static final String PAGE_DELIMITER = "~~~";
-  public static final ItemStack manual = new ItemStack(Items.WRITTEN_BOOK);
+  public static final ItemStack manual;
 
   static {
+    try {
+      manual = loadBook("manual");
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static ItemStack loadBook(String name) throws IOException {
+    ItemStack book = new ItemStack(Items.WRITTEN_BOOK);
     String line;
     int lineNumber = 1;
     StringBuilder page = newPage();
     try(BufferedReader reader = openBookReader("manual")) {
       while ((line = reader.readLine()) != null) {
         if (lineNumber == 1) {
-          manual.setTagInfo("title", new NBTTagString(line));
+          book.setTagInfo("title", new NBTTagString(line));
         } else if (lineNumber == 2) {
-          manual.setTagInfo("author", new NBTTagString(line));
+          book.setTagInfo("author", new NBTTagString(line));
         } else if (PAGE_DELIMITER.equals(line)) {
-          writePage(manual, page);
+          writePage(book, page);
           page = newPage();
         } else {
           page.append(line).append("\n");
         }
         lineNumber++;
       }
-      writePage(manual, page);
-    } catch(IOException e) {
-      throw new UncheckedIOException(e);
     }
+    writePage(book, page);
+    return book;
   }
 
   private static BufferedReader openBookReader(String name) throws FileNotFoundException {


### PR DESCRIPTION
- Remove unused imports
- Only make the book ItemStack once and keep it around, instead of rebuilding
  it every time the manual button is clicked
- Use try-with-resources to make sure the stream gets closed no matter what
- Remove the 50-page check, since it's safe for mods to make books longer
  than this
- Refactor the code to eliminate the chance at some exceptions, and to use
  better exceptions where they're required