### PR TITLE
Remove unnecessary try-catch block

### DIFF
--- a/src/main/java/net/torocraft/minecoprocessors/blocks/TileEntityMinecoprocessor.java
+++ b/src/main/java/net/torocraft/minecoprocessors/blocks/TileEntityMinecoprocessor.java
@@ -241,12 +241,8 @@ public class TileEntityMinecoprocessor extends TileEntity implements ITickable, 
     }
     byte signal = processor.getRegisters()[Register.PF.ordinal() + portIndex];
 
-    try {
-      if (!isADCMode(processor.getRegisters()[Register.ADC.ordinal()], portIndex)) {
-        signal = signal == 0 ? 0 : (byte) 0xff;
-      }
-    }catch (Exception e) {
-      throw new RuntimeException(e);
+    if (!isADCMode(processor.getRegisters()[Register.ADC.ordinal()], portIndex)) {
+      signal = signal == 0 ? 0 : (byte) 0xff;
     }
 
     return signal;


### PR DESCRIPTION
Nothing inside of this try-catch block throws any checked exceptions (if it
did, removing it would cause a compile error), and all unchecked exceptions
are either already RuntimeExceptions (so this is just wrapping an exception
in a less detailed version of itself) or Errors (so this isn't catching them
anyway).