### PR TITLE
More cleanup

### DIFF
--- a/src/main/java/net/torocraft/minecoprocessors/processor/Processor.java
+++ b/src/main/java/net/torocraft/minecoprocessors/processor/Processor.java
@@ -150,10 +150,7 @@ public class Processor implements IProcessor {
     }
 
     byte[] registersNew = new byte[Register.values().length];
-    // FIXME replace with System.arraycopy() ?
-    for (int i = 0; i < registersNew.length && i < registersIn.length; i++) {
-      registersNew[i] = registersIn[i];
-    }
+    System.arraycopy(registersIn, 0, registersNew, 0, registersIn.length);
     return registersNew;
   }
 
@@ -271,6 +268,7 @@ public class Processor implements IProcessor {
         processDiv();
         return;
       case JMP:
+      case LOOP:
         processJmp();
         return;
       case JNZ:
@@ -279,14 +277,14 @@ public class Processor implements IProcessor {
       case JZ:
         processJz();
         return;
-      case LOOP:
-        processJmp();
-        return;
       case MOV:
         processMov();
         return;
       case MUL:
         processMul();
+        return;
+      case NOP:
+      case INT:
         return;
       case NOT:
         processNot();
@@ -303,8 +301,7 @@ public class Processor implements IProcessor {
       case RET:
         processRet();
         return;
-      case NOP:
-        return;
+      case SAL:
       case SHL:
         processShl();
         return;
@@ -320,8 +317,6 @@ public class Processor implements IProcessor {
       case WFE:
         processWfe();
         return;
-      case INT:
-        return;
       case INC:
         processInc();
         return;
@@ -336,9 +331,6 @@ public class Processor implements IProcessor {
         break;
       case JNC:
         processJnc();
-        break;
-      case SAL:
-        processSal();
         break;
       case ROR:
         processRor();
@@ -450,10 +442,6 @@ public class Processor implements IProcessor {
     byte z = (byte) (a >>> b);
     zero = z == 0;
     registers[instruction[1]] = z;
-  }
-
-  void processSal() {
-    processShl();
   }
 
   void processSar() {

--- a/src/test/java/net/torocraft/minecoprocessors/processor/ProcessorTest.java
+++ b/src/test/java/net/torocraft/minecoprocessors/processor/ProcessorTest.java
@@ -391,29 +391,6 @@ public class ProcessorTest {
   }
 
   @Test
-  public void testProcessSal() throws ParseException {
-    Processor processor = setupTest(0b01, 4, 0, 0, "sal a, b");
-    processor.processSal();
-    assertRegisters(processor, 0b010000, 4, 0, 0);
-    Assert.assertFalse(processor.zero);
-
-    processor = setupTest(0b01, 20, 0, 0, "sal a, b");
-    processor.processSal();
-    assertRegisters(processor, 0, 20, 0, 0);
-    Assert.assertTrue(processor.zero);
-
-    processor = setupTest(0, 2, 0, 0, "sal a, b");
-    processor.processSal();
-    assertRegisters(processor, 0, 2, 0, 0);
-    Assert.assertTrue(processor.zero);
-
-    processor = setupTest(0b01, 20, 0, 0, "sal a, 1");
-    processor.processSal();
-    assertRegisters(processor, 0b010, 20, 0, 0);
-    Assert.assertFalse(processor.zero);
-  }
-
-  @Test
   public void testProcessSar() throws ParseException {
     Processor processor = setupTest(0b10000000, 1, 0, 0, "sar a, b");
     processor.processSar();


### PR DESCRIPTION
- Switch to System.arraycopy (and only check the bound that we know is smaller)
- Clean up duplicate instructions