### PR TITLE
More fixes

### DIFF
--- a/src/main/java/net/torocraft/minecoprocessors/processor/Processor.java
+++ b/src/main/java/net/torocraft/minecoprocessors/processor/Processor.java
@@ -355,6 +355,7 @@ public class Processor implements IProcessor {
         break;
       case SEC:
         processSec();
+        break;
       case DUMP:
         processDump();
         break;
@@ -672,7 +673,7 @@ public class Processor implements IProcessor {
     s.append(fix(pad(Integer.toUnsignedString(registers[reg.ordinal()], 16))));
   }
 
-  private void dumpFlag(StringBuilder s, boolean flag) {
+  private static void dumpFlag(StringBuilder s, boolean flag) {
     s.append(flag ? "1 " : "0 ");
   }
 

--- a/src/main/java/net/torocraft/minecoprocessors/util/InstructionUtil.java
+++ b/src/main/java/net/torocraft/minecoprocessors/util/InstructionUtil.java
@@ -335,7 +335,7 @@ public class InstructionUtil {
     }
 
     if (hasMemoryOffset) {
-      int offset = getMemoryOffset(operand);
+      int offset = getMemoryOffset(line, operand);
       instruction = setMemoryOffset(instruction, offset, operandIndex);
       operand = stripMemoryOffset(operand);
     }
@@ -381,12 +381,12 @@ public class InstructionUtil {
   /**
    * Only call this on valid memory offset instructions
    */
-  static int getMemoryOffset(String operand) {
+  static int getMemoryOffset(String line, String operand) throws ParseException {
     String sOffset = operand.replaceAll("[^+^-]*([+-])\\s*([0-9]{1,2})]?", "$1$2");
     try {
       return Integer.parseInt(sOffset);
     } catch (NumberFormatException e) {
-      return 0;
+      throw new ParseException(line, "Invalid memory offset", e);
     }
   }
 
@@ -447,7 +447,7 @@ public class InstructionUtil {
     try {
       Register.valueOf(operand.toUpperCase());
       return true;
-    } catch (IllegalArgumentException ignore) {
+    } catch (@SuppressWarnings("unused") IllegalArgumentException ignore) {
       return false;
     }
   }

--- a/src/test/java/net/torocraft/minecoprocessors/processor/ProcessorTest.java
+++ b/src/test/java/net/torocraft/minecoprocessors/processor/ProcessorTest.java
@@ -153,12 +153,12 @@ public class ProcessorTest {
     processor.testOverflow(-129);
     Assert.assertTrue(processor.overflow);
 
-    processor.testOverflow((long) 129);
+    processor.testOverflow(129L);
     Assert.assertTrue(processor.overflow);
   }
 
   @Test
-  public void testProcessWfe() throws ParseException {
+  public void testProcessWfe() {
     Processor processor = new Processor();
     Assert.assertFalse(processor.isWait());
     processor.processWfe();
@@ -166,7 +166,7 @@ public class ProcessorTest {
   }
 
   @Test
-  public void testProcessHlt() throws ParseException {
+  public void testProcessHlt() {
     Processor processor = new Processor();
     Assert.assertFalse(processor.isFault());
     processor.processHlt();
@@ -174,7 +174,7 @@ public class ProcessorTest {
   }
 
   @Test
-  public void testProcessClz() throws ParseException {
+  public void testProcessClz() {
     Processor processor = new Processor();
     processor.zero = true;
     processor.processClz();
@@ -182,7 +182,7 @@ public class ProcessorTest {
   }
 
   @Test
-  public void testProcessClc() throws ParseException {
+  public void testProcessClc() {
     Processor processor = new Processor();
     processor.carry = true;
     processor.processClc();
@@ -190,7 +190,7 @@ public class ProcessorTest {
   }
 
   @Test
-  public void testProcessSez() throws ParseException {
+  public void testProcessSez() {
     Processor processor = new Processor();
     processor.zero = false;
     processor.processSez();
@@ -198,7 +198,7 @@ public class ProcessorTest {
   }
 
   @Test
-  public void testProcessSec() throws ParseException {
+  public void testProcessSec() {
     Processor processor = new Processor();
     processor.carry = false;
     processor.processSec();
@@ -777,7 +777,7 @@ public class ProcessorTest {
     return processor;
   }
 
-  private void assertRegisters(Processor processor, int a, int b, int c, int d) {
+  private static void assertRegisters(Processor processor, int a, int b, int c, int d) {
     Assert.assertEquals((byte) a, processor.registers[Register.A.ordinal()]);
     Assert.assertEquals((byte) b, processor.registers[Register.B.ordinal()]);
     Assert.assertEquals((byte) c, processor.registers[Register.C.ordinal()]);

--- a/src/test/java/net/torocraft/minecoprocessors/util/InstructionUtilTest.java
+++ b/src/test/java/net/torocraft/minecoprocessors/util/InstructionUtilTest.java
@@ -182,7 +182,7 @@ public class InstructionUtilTest {
     instruction = InstructionUtil.parseLine("DJNZ d, TEST_LABEL2", labels, (short) 0);
     Assert.assertEquals((byte) InstructionCode.DJNZ.ordinal(), instruction[0]);
     Assert.assertEquals((byte) Register.D.ordinal(), instruction[1]);
-    Assert.assertEquals((byte) (byte) 1, instruction[2]);
+    Assert.assertEquals((byte) 1, instruction[2]);
     Assert.assertEquals((byte) 0b00100000, instruction[3]);
   }
 
@@ -230,11 +230,11 @@ public class InstructionUtilTest {
     testParseCompile("SEC ", "sec");
   }
 
-  private void testParseCompile(String in, String out) throws ParseException {
+  private static void testParseCompile(String in, String out) throws ParseException {
     testParseCompile(in, out, (short) 0);
   }
 
-  private void testParseCompile(String in, String out, short address) throws ParseException {
+  private static void testParseCompile(String in, String out, short address) throws ParseException {
     List<Label> labels = new ArrayList<>();
     labels.add(new Label((short) 56, "test"));
     byte[] instruction = InstructionUtil.parseLine(in, labels, (short) 0);
@@ -340,12 +340,16 @@ public class InstructionUtilTest {
     return inst;
   }
 
+  private static int getMemoryOffsetHelper(String operand) throws ParseException {
+    return InstructionUtil.hasMemoryOffset(operand) ? InstructionUtil.getMemoryOffset("dummy", operand) : 0;
+  }
+
   @Test
-  public void getMemoryOffset() {
-    Assert.assertEquals(0, InstructionUtil.getMemoryOffset(""));
-    Assert.assertEquals(0, InstructionUtil.getMemoryOffset("[foo]"));
-    Assert.assertEquals(5, InstructionUtil.getMemoryOffset("[foo + 5]"));
-    Assert.assertEquals(-50, InstructionUtil.getMemoryOffset("foo - 50"));
+  public void getMemoryOffset() throws ParseException {
+    Assert.assertEquals(0, getMemoryOffsetHelper(""));
+    Assert.assertEquals(0, getMemoryOffsetHelper("[foo]"));
+    Assert.assertEquals(5, getMemoryOffsetHelper("[foo + 5]"));
+    Assert.assertEquals(-50, getMemoryOffsetHelper("foo - 50"));
   }
 
   @Test
@@ -375,11 +379,10 @@ public class InstructionUtilTest {
   }
 
   @Test
-  public void parseVariableOperand_invalidLabel() throws ParseException {
+  public void parseVariableOperand_invalidLabel() {
     List<Label> labels = new ArrayList<>();
     labels.add(new Label((short) 90, "foo"));
     labels.add(new Label((short) 35, "label_name"));
-    byte[] instruction;
 
     ParseException e = null;
     try {
@@ -393,7 +396,6 @@ public class InstructionUtilTest {
   @Test
   public void parseVariableOperand_noFreeAdd() {
     List<Label> labels = new ArrayList<>();
-    byte[] instruction;
 
     ParseException e = null;
     try {
@@ -451,7 +453,7 @@ public class InstructionUtilTest {
   }
 
   @Test
-  public void parseDoubleOperands_doubleReference() throws ParseException {
+  public void parseDoubleOperands_doubleReference() {
     List<Label> labels = new ArrayList<>();
     ParseException e = null;
     try {


### PR DESCRIPTION
- Fix accidental fall-through in switch statement
- Make a bunch of methods static
- Make getMemoryOffset throw if there's a problem
- Add some @SuppressWarnings("ignore") annotations
- Remove unnecessary casts
- Remove unnecessary "throws" declarations
- Only test getMemoryOffset on things that it's allowed to be called with
- Remove unused variables