### PR TITLE
Redstone output issue found. Made some cleanups and small changes on the way.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 
 processResources {
   outputs.upToDateWhen { false }
-  doLast { file("${sourceSets.main.output.resourcesDir}/.gitversion").text = 'git log "-1" "--format=%h"'.execute().in.text.trim() }
+  doLast { file("${sourceSets.main.output.resourcesDir}/.gitversion-minecoprocessors").text = 'git log "-1" "--format=%h"'.execute().in.text.trim() }
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # @file gradle.properties
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx8G
-version_forge_minecraft=1.14.4-28.1.109
+version_forge_minecraft=1.14.4-28.1.111
 version_fml_mappings=20190719-1.14.3
 version_minecraft=1.14.4
 version_mod=1.0.5

--- a/src/main/java/net/torocraft/minecoprocessors/ModContent.java
+++ b/src/main/java/net/torocraft/minecoprocessors/ModContent.java
@@ -13,7 +13,6 @@ import net.minecraft.client.gui.ScreenManager;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.tileentity.TileEntityType;
-import net.minecraft.block.material.MaterialColor;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -36,12 +35,12 @@ public class ModContent
 
   public static final MinecoprocessorBlock MINECOPROCESSOR = (MinecoprocessorBlock)(new MinecoprocessorBlock(
     MinecoprocessorBlock.CONFIG_DEFAULT,
-    Block.Properties.create(Material.MISCELLANEOUS, MaterialColor.STONE).hardnessAndResistance(0f, 10f).sound(SoundType.STONE)
+    Block.Properties.create(Material.MISCELLANEOUS).hardnessAndResistance(0f).sound(SoundType.STONE)
   )).setRegistryName(new ResourceLocation(ModMinecoprocessors.MODID, "processor"));
 
   public static final MinecoprocessorBlock MINECOPROCESSOR_OVERCLOCKED = (MinecoprocessorBlock)(new MinecoprocessorBlock(
     MinecoprocessorBlock.CONFIG_OVERCLOCKED,
-    Block.Properties.create(Material.MISCELLANEOUS, MaterialColor.STONE).hardnessAndResistance(0f, 10f).sound(SoundType.STONE)
+    Block.Properties.create(Material.MISCELLANEOUS).hardnessAndResistance(0f).sound(SoundType.STONE)
   )).setRegistryName(new ResourceLocation(ModMinecoprocessors.MODID, "overclocked_processor"));
 
   private static final Block MOD_BLOCKS[] = {

--- a/src/main/java/net/torocraft/minecoprocessors/ModMinecoprocessors.java
+++ b/src/main/java/net/torocraft/minecoprocessors/ModMinecoprocessors.java
@@ -7,7 +7,6 @@
 package net.torocraft.minecoprocessors;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.item.ItemGroup;
@@ -31,6 +30,11 @@ import net.torocraft.minecoprocessors.network.Networking;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
 
 
 @Mod("minecoprocessors")
@@ -45,6 +49,7 @@ public class ModMinecoprocessors
 
   public ModMinecoprocessors()
   {
+    logGitVersion();
     MinecraftForge.EVENT_BUS.register(this);
     // ModLoadingContext.get().registerConfig(net.minecraftforge.fml.config.ModConfig.Type.COMMON, ModConfig.COMMON_CONFIG_SPEC); not needed yet
     ModLoadingContext.get().registerConfig(net.minecraftforge.fml.config.ModConfig.Type.CLIENT, ModConfig.CLIENT_CONFIG_SPEC);
@@ -147,4 +152,20 @@ public class ModMinecoprocessors
     { return new ItemStack(ModContent.MINECOPROCESSOR); }
   });
 
+  // -------------------------------------------------------------------------------------------------------------------
+  // Version info
+  // -------------------------------------------------------------------------------------------------------------------
+
+  public static void logGitVersion()
+  {
+    try {
+      InputStream is = ModMinecoprocessors.class.getResourceAsStream("/.gitversion-" + MODID);
+      if(is==null) return;
+      BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+      String version = br.lines().collect(Collectors.joining("\n"));
+      LOGGER.info(MODNAME + ((version.isEmpty())?(" (dev build)"):(" GIT id #"+version)) + ".");
+    } catch(Throwable e) {
+      return; // don't log resource not there.
+    }
+  }
 }

--- a/src/main/java/net/torocraft/minecoprocessors/blocks/MinecoprocessorTileEntity.java
+++ b/src/main/java/net/torocraft/minecoprocessors/blocks/MinecoprocessorTileEntity.java
@@ -57,8 +57,6 @@ public class MinecoprocessorTileEntity extends TileEntity implements ITickableTi
   private int loadTime;
   private int tickTimer = 0;
 
-  private static void testlog(String s) { System.out.println(s); }
-
   public MinecoprocessorTileEntity()
   { super(ModContent.TET_MINECOPROCESSOR); }
 
@@ -351,7 +349,7 @@ public class MinecoprocessorTileEntity extends TileEntity implements ITickableTi
       outputPower[side.getIndex()] = getPortSignal(portIndex);
       to_update[side.getIndex()] = true;
       updated = true;
-      testlog("out["+portIndex+"]=" + (((int)value)&0xff) + "=" + outputPower[side.getIndex()] + " -> " + side + " -> " + getPos().offset(side));
+      // testlog("out["+portIndex+"]=" + (((int)value)&0xff) + "=" + outputPower[side.getIndex()] + " -> " + side + " -> " + getPos().offset(side));
     }
     // Neighbour block updates
     for(Direction side: Direction.values()) {

--- a/src/main/java/net/torocraft/minecoprocessors/blocks/MinecoprocessorTileEntity.java
+++ b/src/main/java/net/torocraft/minecoprocessors/blocks/MinecoprocessorTileEntity.java
@@ -25,7 +25,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
-import net.minecraftforge.event.ForgeEventFactory;
 import net.torocraft.minecoprocessors.ModContent;
 import net.torocraft.minecoprocessors.ModMinecoprocessors;
 import net.torocraft.minecoprocessors.items.CodeBookItem;
@@ -231,9 +230,9 @@ public class MinecoprocessorTileEntity extends TileEntity implements ITickableTi
   public void tick()
   {
     if((world.isRemote()) || (--tickTimer > 0)) return;
-    final BlockState blockState = world.getBlockState(pos); // @todo --> not sure if the cached getBlockState() would be good here.
-    if(!(blockState.getBlock() instanceof MinecoprocessorBlock)) { tickTimer = 20; return; }
-    final MinecoprocessorBlock block = (MinecoprocessorBlock)blockState.getBlock();
+    final BlockState state = world.getBlockState(pos);
+    if(!(state.getBlock() instanceof MinecoprocessorBlock)) { tickTimer = 20; return; }
+    final MinecoprocessorBlock block = (MinecoprocessorBlock)state.getBlock();
     tickTimer = ((block.config & MinecoprocessorBlock.CONFIG_OVERCLOCKED)!=0) ? 1 : 2;
     boolean dirty = false;
     final boolean hasBook = !inventory.get(0).isEmpty();
@@ -243,11 +242,10 @@ public class MinecoprocessorTileEntity extends TileEntity implements ITickableTi
       initialized = true;
       // This is needed because otherwise the processor will wakeup from sleep after
       // loading, because an input change is detected.
-      updateInputPorts(blockState, true);
+      updateInputPorts(state, true);
     }
     // "Firmware update"
     if(inventoryChanged) {
-      // @todo: ---> moved book loading/unloading to here to have it in sync with the tick.
       inventoryChanged = false;
       customName = loadBook(inventory.get(0), processor);
       prevPortsRegister = processor.getRegister(Register.PORTS);
@@ -258,6 +256,11 @@ public class MinecoprocessorTileEntity extends TileEntity implements ITickableTi
       outputsChanged = true;
       dirty = true;
     } else if(hasBook && (!processor.isFault())) {
+      // Input
+      if(inputsChanged) {
+        inputsChanged = false;
+        updateInputPorts(state, false);
+      }
       // Processor run
       if(processor.tick()) {
         outputsChanged = true;
@@ -272,19 +275,14 @@ public class MinecoprocessorTileEntity extends TileEntity implements ITickableTi
         inputsChanged = true;
         outputsChanged = true;
       }
-      // Input
-      if(inputsChanged) {
-        inputsChanged = false;
-        updateInputPorts(blockState, false);
-      }
     }
     if(outputsChanged) {
       outputsChanged = false;
-      updateOutputs(blockState, block);
+      updateOutputs(state, block);
     }
-    BlockState state = blockState.with(MinecoprocessorBlock.ACTIVE, hasBook && (!processor.isWait()) && (!processor.isFault()));
-    if(state != blockState) {
-      world.setBlockState(pos, state, 1|2|16);
+    BlockState new_state = state.with(MinecoprocessorBlock.POWERED, hasBook && (!processor.isWait()) && (!processor.isFault()));
+    if(state != new_state) {
+      world.setBlockState(pos, new_state, 1|2);
     }
     fields.writeServerSide(processor);
     if(dirty) markDirty();
@@ -320,11 +318,7 @@ public class MinecoprocessorTileEntity extends TileEntity implements ITickableTi
   { inputsChanged = true; } // Update redstone input state
 
   public int getPower(BlockState state, Direction side, boolean strong) //  Invoked from block
-  {
-    int p = outputPower[side.getIndex()];
-    testlog("getPower("+side+", "+(strong?"strong":"weak")+") = "+p);
-    return p;
-  }
+  { return outputPower[side.getOpposite().getIndex()]; } // The updated side of the adjacent block is the opposite side here.
 
   private void onInventoryChanged() // Invoked from inventory methods
   { inventoryChanged = true; tickTimer = 0; }
@@ -342,39 +336,31 @@ public class MinecoprocessorTileEntity extends TileEntity implements ITickableTi
 
   private boolean updateOutputs(final BlockState state, final Block block)
   {
-    //
-    // @review: Combined block methods and detectOutputChange() (were only a few lines in summary after porting).
-    //
-    final Direction front = state.get(MinecoprocessorBlock.HORIZONTAL_FACING).getOpposite();
+    final Direction front = state.get(MinecoprocessorBlock.HORIZONTAL_FACING);
     final byte[] registers = processor.getRegisters();
     final byte ports = processor.getRegister(Register.PORTS);
+    final boolean[] to_update = new boolean[Direction.values().length];
     boolean updated = false;
-
-    //
-    // @todo: I'm fishing in dark waters here to find out how to bloody update the neighbours properly -
-    //
+    // Side power value updates
     for(int portIndex=0; portIndex<4; ++portIndex) {
       byte value = registers[Register.PF.ordinal() + portIndex];
       if(prevPortValues[portIndex] == value) continue;
       prevPortValues[portIndex] = value;
       if(!isInOutputMode(ports, portIndex)) continue;
-      updated = true;
       Direction side = RedstoneUtil.convertPortIndexToFacing(front, portIndex);
-      outputPower[side.getOpposite().getIndex()] = getPortSignal(portIndex);
-      BlockPos neighborPos = getPos().offset(side);
-      if(ForgeEventFactory.onNeighborNotify(world, getPos(), state, java.util.EnumSet.of(side), true).isCanceled()) continue;
-      world.neighborChanged(neighborPos, block, getPos());
-      world.notifyNeighborsOfStateExcept(neighborPos, block, side.getOpposite());
-      testlog("out["+portIndex+"]=" + (((int)value)&0xff) + "=" + outputPower[side.getOpposite().getIndex()] + " -> " + side + " -> " + neighborPos);
+      outputPower[side.getIndex()] = getPortSignal(portIndex);
+      to_update[side.getIndex()] = true;
+      updated = true;
+      testlog("out["+portIndex+"]=" + (((int)value)&0xff) + "=" + outputPower[side.getIndex()] + " -> " + side + " -> " + getPos().offset(side));
     }
-    if(updated) {
-      // world.notifyNeighborsOfStateChange(getPos(), block);
-      //
-      //
-      //world.notifyBlockUpdate(pos, state, state, 1|2);
-      //if(!world.getPendingBlockTicks().isTickPending(pos, block)) {
-      //  world.getPendingBlockTicks().scheduleTick(pos, block, block.tickRate(world), TickPriority.HIGH);
-      //}
+    // Neighbour block updates
+    for(Direction side: Direction.values()) {
+      if(!to_update[side.getIndex()]) continue;
+      to_update[side.getIndex()] = false;
+      BlockPos neighborPos = pos.offset(side);
+      if(net.minecraftforge.event.ForgeEventFactory.onNeighborNotify(world, pos, state, java.util.EnumSet.of(side), false).isCanceled()) continue;
+      world.neighborChanged(neighborPos, block, pos);
+      world.notifyNeighborsOfStateExcept(neighborPos, block, side.getOpposite());
     }
     return updated;
   }
@@ -384,7 +370,7 @@ public class MinecoprocessorTileEntity extends TileEntity implements ITickableTi
     //
     // @review: included updateInputPort() here to have for reusing local vars on the stack.
     //
-    final Direction front = state.get(MinecoprocessorBlock.HORIZONTAL_FACING).getOpposite();
+    final Direction front = state.get(MinecoprocessorBlock.HORIZONTAL_FACING);
     final byte[] registers = processor.getRegisters();
     final byte ports = processor.getRegister(Register.PORTS);
     final byte adc = processor.getRegister(Register.ADC);

--- a/src/main/java/net/torocraft/minecoprocessors/gui/MinecoprocessorGui.java
+++ b/src/main/java/net/torocraft/minecoprocessors/gui/MinecoprocessorGui.java
@@ -87,6 +87,7 @@ public class MinecoprocessorGui extends ContainerScreen<MinecoprocessorContainer
     renderBackground();
     super.render(mouseX, mouseY, partialTicks);
     renderHoveredToolTip(mouseX, mouseY);
+    getContainer().checkResync();
   }
 
   @Override
@@ -285,7 +286,11 @@ public class MinecoprocessorGui extends ContainerScreen<MinecoprocessorContainer
     String label = "NEXT";
     String value = "";
     int color = 0xffffff;
-    if(getContainer().getFields().isLoaded()) {
+    if((!getContainer().getProcessorError().isEmpty()) || (getContainer().getFields().isFault())) {
+      label = "ERROR";
+      value = getContainer().getProcessorError();
+      color = 0xff0000;
+    } else if(getContainer().getFields().isLoaded()) {
       Processor processor = getContainer().getProcessor();
       byte[] a = null;
       if(processor != null) {
@@ -301,10 +306,6 @@ public class MinecoprocessorGui extends ContainerScreen<MinecoprocessorContainer
       }
       if (a != null) {
         value = InstructionUtil.compileLine(a, processor.getLabels(), (short) -1);
-      }
-      if (value.isEmpty() && (!getContainer().getProcessorError().isEmpty())) {
-        value = getContainer().getProcessorError();
-        color = 0xff0000;
       }
     }
     font.drawString(label, x - 4, y - 14, 0x404040);

--- a/src/main/resources/assets/minecoprocessors/blockstates/overclocked_processor.json
+++ b/src/main/resources/assets/minecoprocessors/blockstates/overclocked_processor.json
@@ -1,12 +1,12 @@
 {
 	"variants": {
-		"active=true,facing=south":  { "model": "minecoprocessors:block/minecoprocessor_overclocked_on"            },
-		"active=true,facing=west":   { "model": "minecoprocessors:block/minecoprocessor_overclocked_on",  "y": 90  },
-		"active=true,facing=north":  { "model": "minecoprocessors:block/minecoprocessor_overclocked_on",  "y": 180 },
-		"active=true,facing=east":   { "model": "minecoprocessors:block/minecoprocessor_overclocked_on",  "y": 270 },
-		"active=false,facing=south": { "model": "minecoprocessors:block/minecoprocessor_overclocked_off"           },
-		"active=false,facing=west":  { "model": "minecoprocessors:block/minecoprocessor_overclocked_off", "y": 90  },
-		"active=false,facing=north": { "model": "minecoprocessors:block/minecoprocessor_overclocked_off", "y": 180 },
-		"active=false,facing=east":  { "model": "minecoprocessors:block/minecoprocessor_overclocked_off", "y": 270 }
+		"powered=true,facing=south":  { "model": "minecoprocessors:block/minecoprocessor_overclocked_on",  "y": 180 },
+		"powered=true,facing=west":   { "model": "minecoprocessors:block/minecoprocessor_overclocked_on",  "y": 270 },
+		"powered=true,facing=north":  { "model": "minecoprocessors:block/minecoprocessor_overclocked_on",  "y": 0   },
+    "powered=true,facing=east":   { "model": "minecoprocessors:block/minecoprocessor_overclocked_on",  "y": 90  },
+		"powered=false,facing=south": { "model": "minecoprocessors:block/minecoprocessor_overclocked_off", "y": 180 },
+		"powered=false,facing=west":  { "model": "minecoprocessors:block/minecoprocessor_overclocked_off", "y": 270 },
+		"powered=false,facing=north": { "model": "minecoprocessors:block/minecoprocessor_overclocked_off", "y": 0   },
+		"powered=false,facing=east":  { "model": "minecoprocessors:block/minecoprocessor_overclocked_off", "y": 90  }
 	}
 }

--- a/src/main/resources/assets/minecoprocessors/blockstates/processor.json
+++ b/src/main/resources/assets/minecoprocessors/blockstates/processor.json
@@ -1,12 +1,12 @@
 {
 	"variants": {
-		"active=true,facing=south":  { "model": "minecoprocessors:block/minecoprocessor_on"            },
-		"active=true,facing=west":   { "model": "minecoprocessors:block/minecoprocessor_on",  "y": 90  },
-		"active=true,facing=north":  { "model": "minecoprocessors:block/minecoprocessor_on",  "y": 180 },
-		"active=true,facing=east":   { "model": "minecoprocessors:block/minecoprocessor_on",  "y": 270 },
-		"active=false,facing=south": { "model": "minecoprocessors:block/minecoprocessor_off"           },
-		"active=false,facing=west":  { "model": "minecoprocessors:block/minecoprocessor_off", "y": 90  },
-		"active=false,facing=north": { "model": "minecoprocessors:block/minecoprocessor_off", "y": 180 },
-		"active=false,facing=east":  { "model": "minecoprocessors:block/minecoprocessor_off", "y": 270 }
+		"powered=true,facing=south":  { "model": "minecoprocessors:block/minecoprocessor_on",  "y": 180 },
+		"powered=true,facing=west":   { "model": "minecoprocessors:block/minecoprocessor_on",  "y": 270 },
+		"powered=true,facing=north":  { "model": "minecoprocessors:block/minecoprocessor_on",  "y": 0   },
+    "powered=true,facing=east":   { "model": "minecoprocessors:block/minecoprocessor_on",  "y": 90  },
+		"powered=false,facing=south": { "model": "minecoprocessors:block/minecoprocessor_off", "y": 180 },
+		"powered=false,facing=west":  { "model": "minecoprocessors:block/minecoprocessor_off", "y": 270 },
+		"powered=false,facing=north": { "model": "minecoprocessors:block/minecoprocessor_off", "y": 0   },
+		"powered=false,facing=east":  { "model": "minecoprocessors:block/minecoprocessor_off", "y": 90  }
 	}
 }


### PR DESCRIPTION
Finally ;-). `Block.shouldCheckWeakPower()` is not an input related override, but output - and must be `false` because it marks that blocks propagate strong power or not.