### PR TITLE
Digital GPIOs values clamped 0x0 or 0x1. Added Input Data Register (IDR) and Output Data Register feature (ODR).

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.jvmargs=-Xmx8G
 version_minecraft=1.16.5
 version_forge_minecraft=1.16.4-35.1.10
 version_fml_mappings=20201028-1.16.3
-version_mod=1.0.5-b1
+version_mod=1.0.5-b2

--- a/src/main/java/net/torocraft/minecoprocessors/ModConfig.java
+++ b/src/main/java/net/torocraft/minecoprocessors/ModConfig.java
@@ -45,7 +45,13 @@ public class ModConfig
   }
 
   public static void onFileChange(final net.minecraftforge.fml.config.ModConfig config)
-  {}
+  {
+    try {
+      apply();
+    } catch(Exception ex) {
+      ModMinecoprocessors.logger().error("Failed to apply config file data {}", config.getFileName());
+    }
+  }
 
   //--------------------------------------------------------------------------------------------------------------------
 
@@ -61,7 +67,7 @@ public class ModConfig
         code_book_max_columns_per_line = builder
           .translation(MODID + ".config.code_book_max_columns_per_line")
           .comment("Defines the maximum line length in the Code Book.")
-          .defineInRange("code_book_max_columns_per_line", 18, 10, 80);
+          .defineInRange("code_book_max_columns_per_line", 22, 10, 80);
       }
       builder.pop();
     }
@@ -96,7 +102,7 @@ public class ModConfig
   // Cache fields
   //--------------------------------------------------------------------------------------------------------------------
 
-  public static int maxColumnsPerLine = 20;
+  public static int maxColumnsPerLine = 22;
   public static int maxLinesPerPage = 20;
   public static int codeBookTextColor = 0xFF333333;
   public static int codeBookSelectedTextColor = 0xFFEEEEEE;

--- a/src/main/java/net/torocraft/minecoprocessors/ModMinecoprocessors.java
+++ b/src/main/java/net/torocraft/minecoprocessors/ModMinecoprocessors.java
@@ -110,7 +110,7 @@ public class ModMinecoprocessors
   // Sided proxy functionality
   // -------------------------------------------------------------------------------------------------------------------
 
-  public static final ISidedProxy proxy = DistExecutor.runForDist(()->ClientProxy::new, ()->ServerProxy::new);
+  public static final ISidedProxy proxy = DistExecutor.unsafeRunForDist(()->ClientProxy::new, ()->ServerProxy::new);
 
   public interface ISidedProxy
   {

--- a/src/main/java/net/torocraft/minecoprocessors/blocks/MinecoprocessorBlock.java
+++ b/src/main/java/net/torocraft/minecoprocessors/blocks/MinecoprocessorBlock.java
@@ -8,6 +8,8 @@ package net.torocraft.minecoprocessors.blocks;
 
 import net.minecraft.block.*;
 import net.minecraft.block.material.PushReaction;
+import net.minecraft.entity.EntitySpawnPlacementRegistry;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -60,19 +62,14 @@ public class MinecoprocessorBlock extends HorizontalBlock
   public VoxelShape getShape(BlockState state, IBlockReader source, BlockPos pos, ISelectionContext selectionContext)
   { return SHAPE; }
 
-//  @Override
-//  @SuppressWarnings("deprecation")
-//  public boolean isNormalCube(BlockState state, IBlockReader worldIn, BlockPos pos)
-//  { return false; }
-
   @Override
   public boolean canSpawnInBlock()
   { return false; }
 
-//  @Override
-//  @SuppressWarnings("deprecation")
-//  public boolean canEntitySpawn(BlockState state, IBlockReader worldIn, BlockPos pos, EntityType<?> type)
-//  { return false; }
+  @Override
+  @SuppressWarnings("deprecation")
+  public boolean canCreatureSpawn(BlockState state, IBlockReader world, BlockPos pos, EntitySpawnPlacementRegistry.PlacementType type, @Nullable EntityType<?> entityType)
+  { return false; }
 
   @Override
   @SuppressWarnings("deprecation")
@@ -207,10 +204,6 @@ public class MinecoprocessorBlock extends HorizontalBlock
   @SuppressWarnings("deprecation")
   public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder)
   { return Collections.singletonList(ItemStack.EMPTY); }
-
-//  @Override
-//  public int tickRate(IWorldReader world)
-//  { return 2; }
 
   @Override
   @SuppressWarnings("deprecation")

--- a/src/main/java/net/torocraft/minecoprocessors/blocks/MinecoprocessorGui.java
+++ b/src/main/java/net/torocraft/minecoprocessors/blocks/MinecoprocessorGui.java
@@ -5,7 +5,6 @@
 package net.torocraft.minecoprocessors.blocks;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.ReadBookScreen;
 import net.minecraft.client.gui.screen.inventory.ContainerScreen;

--- a/src/main/java/net/torocraft/minecoprocessors/items/CodeBookGui.java
+++ b/src/main/java/net/torocraft/minecoprocessors/items/CodeBookGui.java
@@ -73,7 +73,7 @@ public class CodeBookGui extends ContainerScreen<CodeBookContainer>
   // -------------------------------------------------------------------------------------------------------------------
 
   private static int getMaxColumns()
-  { return MathHelper.clamp(ModConfig.maxColumnsPerLine, 8, 20); }
+  { return MathHelper.clamp(ModConfig.maxColumnsPerLine, 8, 25); }
 
   private static int getMaxLinesPerPage()
   { return MathHelper.clamp(ModConfig.maxLinesPerPage, 12, MAX_LINES_PER_PAGE); }

--- a/src/main/java/net/torocraft/minecoprocessors/network/Networking.java
+++ b/src/main/java/net/torocraft/minecoprocessors/network/Networking.java
@@ -239,38 +239,4 @@ public class Networking
     }
   }
 
-  //--------------------------------------------------------------------------------------------------------------------
-  // Item data synchrsonisation
-  //--------------------------------------------------------------------------------------------------------------------
-
-  public interface INetworkSynchronisableItem
-  {
-    void onServerPacketReceived(int stackid, PlayerEntity player, CompoundNBT nbt);
-    void onClientPacketReceived(int stackid, PlayerEntity player, CompoundNBT nbt);
-  }
-
-  public static class PacketItemSyncClientToServer
-  {
-    // @todo check and implement (may also be converted to a player slot sync, depending what MC already offers).
-    /// Purpose / reference for this is 1.12 MessageBookCodeData:
-    //
-    //  public static final class Handler extends AbstractMessageHandler<MessageBookCodeData> {
-    //
-    //    @Override
-    //    protected void onMessageSynchronized(final MessageBookCodeData message, final MessageContext context) {
-    //      final EntityPlayer player = context.getServerHandler().player;
-    //      if (player != null) {
-    //        final ItemStack stack = player.getHeldItem(EnumHand.MAIN_HAND);
-    //        if (CodeBookItem.isBookCode(stack)) {
-    //          final CodeBookItem.Data data = CodeBookItem.Data.loadFromNBT(message.getNbt());
-    //          CodeBookItem.Data.saveToStack(stack, data);
-    //        }
-    //      }
-    //    }
-    //  }
-  }
-
-  public static class PacketItemSyncServerToClient
-  {}
-
 }

--- a/src/main/java/net/torocraft/minecoprocessors/processor/Processor.java
+++ b/src/main/java/net/torocraft/minecoprocessors/processor/Processor.java
@@ -854,13 +854,20 @@ public class Processor
     return s;
   }
 
-
   public byte[] getRegisters() {
     return registers;
   }
 
   public byte getRegister(Register reg) {
     return registers[reg.ordinal()];
+  }
+
+  public void setRegister(Register reg, byte value) {
+    registers[reg.ordinal()] = value;
+  }
+
+  public void setRegister(int regIndex, byte value) {
+    registers[regIndex] = value;
   }
 
   public List<byte[]> getProgram() {

--- a/src/main/java/net/torocraft/minecoprocessors/processor/Register.java
+++ b/src/main/java/net/torocraft/minecoprocessors/processor/Register.java
@@ -52,5 +52,15 @@ public enum Register {
    *
    * <ul> <li><b>bit 0:</b> front port</li> <li><b>bit 1:</b> back port</li> <li><b>bit 2:</b> left port</li> <li><b>bit 3:</b> right port</li> </ul>
    */
-  ADC
+  ADC,
+  /**
+   * Digital Input Data Register (reads all input ports as nibble).
+   * Bit order: (pf<<0)|(pb<<1)|(pl<<2)|(pr<<3)
+   */
+  IDR,
+  /**
+   * Digital Output Data Register (writes all ports as nibble)
+   * Bit order: (pf<<0)|(pb<<1)|(pl<<2)|(pr<<3)
+   */
+  ODR,
 }

--- a/src/main/java/net/torocraft/minecoprocessors/util/BookCreator.java
+++ b/src/main/java/net/torocraft/minecoprocessors/util/BookCreator.java
@@ -1,10 +1,5 @@
 package net.torocraft.minecoprocessors.util;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
@@ -13,6 +8,15 @@ import net.minecraft.nbt.StringNBT;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.torocraft.minecoprocessors.ModMinecoprocessors;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 
 public class BookCreator

--- a/src/main/java/net/torocraft/minecoprocessors/util/BookCreator.java
+++ b/src/main/java/net/torocraft/minecoprocessors/util/BookCreator.java
@@ -1,11 +1,10 @@
 package net.torocraft.minecoprocessors.util;
 
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
@@ -61,7 +60,14 @@ public class BookCreator
   private static BufferedReader openBookReader(String name) throws FileNotFoundException
   {
     String path = PATH + name + ".txt";
-    InputStream is = BookCreator.class.getResourceAsStream(path);
+    InputStream is = null;
+    try {
+      final File writing = new File(name + ".txt"); // For the process or writing the manual as text file:
+      if(writing.isFile() && writing.canRead()) is = new FileInputStream(writing);
+    } catch(Throwable ex) {
+      is = null; // This error shall be ignored in normal use.
+    }
+    if(is == null) is = BookCreator.class.getResourceAsStream(path);
     if(is == null) throw new FileNotFoundException("Book file not found [" + path + "]");
     return new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
   }

--- a/src/main/resources/assets/minecoprocessors/lang/en_us.json
+++ b/src/main/resources/assets/minecoprocessors/lang/en_us.json
@@ -6,7 +6,7 @@
  "block.minecoprocessors.processor":"Redstone Processor",
  "block.minecoprocessors.overclocked_processor":"Overclocked Processor",
  "item.minecoprocessors.code_book":"Processor Code Book",
- "item.minecoprocessors.code_book.tooltip":"§8Specical editing book to facilitate programming the Redstone Processor.§r",
+ "item.minecoprocessors.code_book.tooltip":"§8Specical editing book\n§8to facilitate programming\n§8the Redstone Processor.§r",
  "item.minecoprocessors.code_book.tooltip.noprogram":"§6(empty)",
  "item.minecoprocessors.code_book.tooltip.program":"§6Program: %1$s§r",
  "item.minecoprocessors.code_book.tooltip.numpages":"§6Pages: %1$s§r",

--- a/src/main/resources/data/minecoprocessors/books/manual.txt
+++ b/src/main/resources/data/minecoprocessors/books/manual.txt
@@ -14,12 +14,11 @@ Minecoprocessors
 ~~~
 §nIndex§r
 
-The first pages of this manual are dense "cheat sheets". A more detailed introduction starts at page §l10§r.
+The first pages of this manual are dense "cheat sheets". A more detailed §ointroduction§r starts at page §o10§r.
 
-Some examples are attached as appendix.
+Some §oexamples§r are attached as appendix, starting at page §o33§r.
 
-
-
+Have fun coding!
 ~~~
 §nI/O Registers§r
 
@@ -58,9 +57,9 @@ Bit order for §1ports§r, §1adc§r, §1idr§r, §1odr§r: front (0001b), back 
 
 
 
-
-
-§o(Results stored in §1a§r§o).§r
+§o(Results stored in §1a§r§o,§r
+§ooperations are§r
+§owithout carry).§r
 ~~~
 §nLogical Instructions§r
 
@@ -189,7 +188,7 @@ Signals are accessible primarily through the registers §1pf pb pl pr§r:
 
 Gray annotated are the binary bit values to configure the I/Os in the §1ports§r and §1adc§r registers.
 ~~~
-The first instruction in a listing is normally to write the register §1ports§r, where cleared bit configure outputs and set bits inputs. E.g.
+The first instruction in a listing is normally to write the register §1ports§r, where cleared bits define outputs, and set bits configure inputs. E.g.:
 
   §1MOV ports, 1010b§r
 
@@ -245,9 +244,73 @@ the numeric value is less than zero, and therefore limited to 0.
 
   §1MOV pf, 20§r
 
-... is clamped to 15 without wrap-over, too.
+... is clamped to §415§r without wrap-over, too.
 ~~~
+§nCompare and Carry§r
 
+This CPU has three operations affecting
+the Carry (§1C§r) flag: §1CMP§r, §1SEC§r, and §1CLC§r. The
+latter two explicitly set or clear §1C§rarry.
+§1CMP§r means comparing, which is §osubtracting§r
+without writing back the value, and instead
+changing the flags §1C§rarry and §1Z§rero.
+~~~
+These two flags can then be used to §ojump§r:
+
+  §1CMP a, b§r
+  §1JZ §4equal§r
+  §1JC §4less§r
+ §4greater§r:
+  §1JMP §4done§r
+ §4equal§r:
+  §1JMP §4done§r
+ §4less§r:
+  §1JMP §4done§r
+ §4done§r:
+  §7; Code after cond.§r
+~~~
+§nZero flag§r
+
+The §1Z§r flag is set when an operation result is
+zero. This can also be used to jump:
+
+  §1AND pb, 0xff§r
+  §1JNZ §4powered§r
+ §4unpowered§r:
+  §1JMP §4done§r
+ §4powered§r:
+  §1JMP §4done§r
+ §4done§r:
+~~~
+§nFault flag§r
+
+When a fault occurs, be it from invalid code
+or from arithmetics (e.g. division by zero),
+the processor halts and sets the fault (§1F§r)
+flag. The instruction pointer (§1IP§r) and the
+text in the upper left instruction field tell
+you where and what.
+~~~
+§nSleep flag§r
+
+You can put the CPU manually into sleep mode (§1S§r) for debug stepping (see buttons on the left side).
+
+In normal operation, the CPU can also sleep until something changes at the input sides. This feature
+is very interesting to
+~~~
+read inputs on change and start processing:
+
+ §4loop§r:
+  §1WFE§r
+  §8; Wake on change§r
+  §1MOV d, idr§r
+ §4process§r:
+  §1MOV a, d§r
+  §1AND a, 1110b§r
+  ...
+  ...
+  §1JMP §4loop§r
+~~~
 
 
 

--- a/src/main/resources/data/minecoprocessors/books/manual.txt
+++ b/src/main/resources/data/minecoprocessors/books/manual.txt
@@ -1,130 +1,291 @@
 Redstone Processor Manual
 Minecoprocessors
+§r
+§r
+§r   Minecoprocessors
+§r
+§r        Redstone
+§r       Processor
+§r        Manual
+§r
+§r
+§r
+§oVisit the Wiki§r §1https://github.com/ToroCraft/Minecoprocessors/wiki§r
+~~~
+§nIndex§r
 
-  Minecoprocessors
+The first pages of this manual are dense "cheat sheets". A more detailed introduction starts at page §l10§r.
 
-       Redstone
-      Processor
-        Manual
+Some examples are attached as appendix.
+
+
 
 ~~~
-§1Visit the Wiki§r
+§nI/O Registers§r
 
-For more information, visit the wiki:
+§1pf, pb, pl, pr§r: I/Os
 
-https://github.com/ToroCraft/Minecoprocessors/wiki
+§1ports§r: I/O config
+§1adc§r: ADC config
+§1idr§r: Input data reg
+§1odr§r: Output data reg
+
+Bit order for §1ports§r, §1adc§r, §1idr§r, §1odr§r: front (0001b), back (0010b), left (0100b), right (1000b)§r.
 ~~~
-§1Instructions§r
+§nBasic Instructions§r
 
-§lMOV a, b§r Move
-§lPUSH a§r Push to Stack
-§lPOP a§r Pop from Stack
-§lNOP§r No Operation
-§lHLT§r Halt Processor
-§lCLC§r Clear Carry
-§lSEC§r Set Carry
-§lCLZ§r Clear Zero
-§lSEZ§r Set Zero
-§lHLT§r Halt Processor
-§lWFE§r Sleep (experimental)
+§1MOV a, b§r Move/assign
+§1NOP§r No Operation
+§1CLC§r Clear Carry
+§1SEC§r Set Carry
+§1CLZ§r Clear Zero
+§1SEZ§r Set Zero
+
+§1PUSH a§r Push to Stack
+§1POP a§r Pop from Stack
+
+§1WFE§r Wait For Event
+§1HLT§r Halt Processor
 ~~~
-§1Arithmetic Instructions§r
+§nArithmetic Instructions§r
 
-§lADD a, b§r Add
-§lSUB a, b§r Subtract
-§lMUL a§r Multiply
-§lDIV a§r Divide
-§lINC a§r Increment by 1
-§lDEC a§r Decrement by 1
+§1ADD a, b§r Add
+§1SUB a, b§r Subtract
+§1MUL a§r Multiply
+§1DIV a§r Divide
+§1INC a§r Increment by 1
+§1DEC a§r Decrement by 1
+
+
+
+
+
+§o(Results stored in §1a§r§o).§r
 ~~~
-§1Logical Instructions§r
+§nLogical Instructions§r
 
-§lAND a, b§r Bitwise AND
-§lOR a, b§r Bitwise OR
-§lXOR a, b§r Bitwise XOR
-§lNOT a§r Bitwise NOT
+§1AND a, b§r Bitwise AND
+§1OR a, b§r Bitwise OR
+§1XOR a, b§r Bitwise XOR
+§1NOT a§r Bitwise NOT
+
+
+
+
+
+
+
+§o(Results stored in §1a§r§o).§r
 ~~~
-§1Shift Instructions§r
+§nShift Instructions§r
 
-§lSHL a§r Shift Left
-§lSHR a§r Shift Right
-§lSAR a§r Arithmetic Right
-§lSAL a§r Arithmetic Left
-§lROR a§r Rotate Right
-§lROL a§r Rotate Right
+§1SHL a§r Shift Left
+§1SHR a§r Shift Right
+§1SAR a§r Arithmetic Right
+§1SAL a§r Arithmetic Left
+§1ROR a§r Rotate Right
+§1ROL a§r Rotate Right
+
+
+
+
+
+§o(Results stored in §1a§r§o).§r
 ~~~
-§1Loop Instructions§r
+§nFlow Control Instr.§r
 
-§lJMP label§r Jump
-§lJZ label§r Jump if Zero
-§lJNZ label§r not Zero
-§lJC label§r if Carry
-§lJNC label§r if no Carry
-§lDJNZ a, label§r Dec and Jump if not zero
-§lCALL label§r Call
-§lRET§r Return
-§lCMP a, b§r Compare
+§1CMP a, b§r Compare
+§1JMP label§r Jump
+§1JZ label§r Jump if Zero
+§1JNZ label§r not Zero
+§1JC label§r if Carry
+§1JNC label§r if no Carry
+§1DJNZ a, label§r Dec and Jump if not zero
+§1CALL label§r Call
+§1RET§r Return
 ~~~
-§1Number Formats§r
+§nFlags§r
 
-§l-1§r two's complement
-§l0xff§r Hexadecimal
-§l0o377§r Octal
-§l11111111b§r Binary
-~~~
-§1Registers§r
+§1Z§r Zero Flag
+§1C§r Carry Flag
+§1F§r Fault Flag
+§1S§r Sleep Flag
 
-The redstone processor has four one byte general purpose registers:
-§la b c d§r
-along with four port registers:
-§lpf pb pl pr§r
-which control the font, back, left and right ports respectively.
-~~~
-§1Ports§r
 
-There is one additional register, §lports§r, that is used to set mode of the ports. There are three modes that the ports can be set to: input, output or reset.
-~~~
-Put a zero value in corresponding low nibble bit to set a port as an output, or set it to one to use it as an input port.
 
-Set the corresponding bits in both the high and low nibble to use the port as a reset port.
-~~~
-§1Flags§r
 
-§lZ§r Zero Flag
-§lC§r Carry Flag
-§lF§r Fault Flag
-§lS§r Sleep Flag
+
+
 ~~~
 
- Example Programs
+
+
+     §o§lIntroduction§r
 
 ~~~
-§1Repeater§r
+§nSyntax§r
 
-mov ports, 0010b
+In assembly language we do one operation per line. Each line starts with an instruction, followed by arguments, e.g.:
+
+ §1MOV a, 10§r
+
+assigns 10 to the register §1a§r ("§1a = 10§r").
+~~~
+Instructions which calculate something normally store the result back in the first argument, hence,
+
+ §1MOV a, 12§r
+ §1MOV b, 10§r
+ §1SUB a, b§r
+
+will result in register §1a§r containing §12§r as present value.
+
+~~~
+Comments start with a semicolon:
+
+ §1; This is a comment§r
+
+Labels allow to name program addresses. They are used for conditions, loops, or functions:
+
+§4start:§r
+ §1JMP§r §4start§r
+~~~
+Numbers can be hex, decimal, octal, as well as binary. A byte with all bits set (§11§r) can be written as:
+
+Hexadecimal: §10xff§r
+Decimal: §1-1§r
+Octal: §10o377§r
+Binary: §111111111b§r
+
+The decimal value above is equal to §1-1§r because the byte is ...
+~~~
+interpreted as signed value. That means the highest bit §110000000b§r adds §1-128§r to all other bits, which add §11§r, §12§r, §14§r, §18§r, §116§r, §132§r, and §164§r to the value.
+
+In most cases, binary or hexadecimal representations are best, as we are often dealing with the bits in registers.
+~~~
+§nCore Registers§r
+
+The CPU has four one byte registers §1a, b, c,§r and §1d§r to store values and calculate.
+
+These "variables" do not change any of the signals outside the CPU - they are only internal.
+~~~
+§nPorts and Port Config§r
+
+The CPU interacts with the world around via special registers. These are mapped to the four sides of the device, and we need to tell the CPU if we like to read signals from a side, or want to output redstone power there.
+
+Additionally, we can
+~~~
+specify for each I/O if we are interested in the numeric "strength" value of the signal, or only the on/off data.
+§oAlso known as §1analog§r and §1digital§r mode.§r
+
+Lastly, ports can also be used to reset the controller by leaving a side unconfigured or "unconfiguring" it explicitly.
+
+~~~
+Signals are accessible primarily through the registers §1pf pb pl pr§r:
+
+§80001b | §1pf§r : front
+§80010b | §1pb§r : back
+§80100b | §1pl§r  : left
+§81000b | §1pr§r : right
+
+Gray annotated are the binary bit values to configure the I/Os in the §1ports§r and §1adc§r registers.
+~~~
+The first instruction in a listing is normally to write the register §1ports§r, where cleared bit configure outputs and set bits inputs. E.g.
+
+  §1MOV ports, 1010b§r
+
+defines §1pf§r and §1pl§r as outputs, §1pb§r and §1pr§r as inputs. To use an I/O for reset, set its bit
+~~~
+in the low and high nibble:
+
+  §1MOV ports, 0x33§r
+
+configures §1pf§r and §1pb§r as reset, §1pl§r and §1pr§r as output.
+
+By default I/Os are in digital mode. Hence, we read the value §10x00§r if an input signal is §40§r, and §10x01§r for any
+~~~
+strength from §41§r to §415§r.
+Reversely, writing §10§r to an output will result in an unpowered side, while any other value will yield strength §415§r.
+
+  §1MOV pf, 0§r
+  §1MOV pf, 1b§r
+  §1MOV pf, 0x0e§r
+  §1MOV pf, -3§r
+
+Signal §40§r in the first case, others §415§r.
+~~~
+Multiple digital I/Os can be read/written simultaneously using Input/Output Data Registers §1idr§r and §1odr§r:
+
+  §1MOV a, idr§r
+  §1MOV odr, 0110b§r
+
+The §1idr§r reads set bits of output ports as 1. These registers can be useful to latch ports in one tick, and
+
+~~~
+process the data afterwards.
+Analog configuration is done like the port direction setting, but using register §1adc§r:
+
+  §1MOV ports, 0010b§r
+  §1MOV adc  , 1110b§r
+
+§1pf§r is digital output, §1pb§r analog input (ADC), §1pr§r and §1pl§r analog outputs
+(DACs). All ADCs will
+~~~
+read the exact input strength between §40§r (§10x0§r) and §415§r (§10xf§r).
+
+DACs will output the register values limited from §10§r to §115§r.
+
+  §1MOV ports, 0000b§r
+  §1MOV adc  , 0011b§r
+  §1MOV pf    , 10§r
+  §1MOV pb    , -1§r
+
+Front: §410§r, back: §40§r, as
+~~~
+the numeric value is less than zero, and therefore limited to 0.
+
+  §1MOV pf, 20§r
+
+... is clamped to 15 without wrap-over, too.
+~~~
+
+
+
+
+ §o§lExample Programs§r
+
+
+~~~
+§nSimple Repeater§r
+
+
+
+ §1MOV ports, 0010b§r
 start:
-mov pf, pb
-jmp start
+ §1MOV pf, pb§r
+ §1JMP§r start
 ~~~
-§13 Input AND Gate§r
+§n3 Input AND Gate§r
 
-mov ports, 1110b
+
+
+ §1MOV ports, 1110b§r
 start:
-mov a, pb
-and a, pl
-and a, pr
-mov pf, a
-jmp start
+ §1MOV a, pb§r
+ §1AND a, pl§r
+ §1AND a, pr§r
+ §1MOV pf, a§r
+§1jmp§r start
 ~~~
-§1Enabled-clock§r
-§1Pulse Multiplier§r
+§nEnabled-clock§r
+§nPulse Multiplier§r
 
-mov ports, 0010b
+
+ §1MOV ports, 0010b§r
 start:
-cmp pb, 0
-jz off
-not pf
-jmp start
+ §1CMP pb, 0§r
+ §1JZ§r off
+ §1NOT pf§r
+ §1JMP§r start
 off:
-mov pf, 0
-jmp start
+ §1MOV pf, 0§r
+ §1JMP§r start


### PR DESCRIPTION
Hi, @frodare, I played along a bit with additional use cases of the mod and addressed the digital mode value range in one go.
The main change is adding the two registers IDR and ODR to read/write the bit encoded data words of all I/Os. That could be interesting to latch inputs as a consistent state of one tick before processing.

Also extended the manual as I have the impression people do read this prior to checking the wiki pages and need some kind of brief introduction in-game. Now, I am not a native EN, so I would feel relieved if you could risk a glimpse for typos or strange formulations.

Keep it up, cheers, wile.